### PR TITLE
JENKINS-61336 fix: make dashboard view plugin integration optional

### DIFF
--- a/src/main/java/org/korosoft/jenkins/plugin/rtp/RichTextPortlet.java
+++ b/src/main/java/org/korosoft/jenkins/plugin/rtp/RichTextPortlet.java
@@ -126,7 +126,7 @@ public class RichTextPortlet extends DashboardPortlet {
         return j.getJobNames();
     }
 
-    @Extension
+    @Extension(optional = true)
     public static class DescriptorImpl extends Descriptor<DashboardPortlet> {
         @Override
         public String getDisplayName() {

--- a/src/main/java/org/korosoft/jenkins/plugin/rtp/StaticTextPortlet.java
+++ b/src/main/java/org/korosoft/jenkins/plugin/rtp/StaticTextPortlet.java
@@ -107,7 +107,7 @@ public class StaticTextPortlet extends DashboardPortlet {
         return markupParser;
     }
 
-    @Extension
+    @Extension(optional = true)
     public static final class DescriptorImpl extends Descriptor<DashboardPortlet> {
 
         private static transient Map<String, MarkupParser> markupParsers;


### PR DESCRIPTION
Currently if you don't have the [dashboard view](https://plugins.jenkins.io/dashboard-view/) plugin installed, the Rich Text Publisher will throw an error in the system log, and we don't want that to happen.

I'm replicating this fix from how this was fixed for a couple other plugins
- [JENKINS-20027](https://issues.jenkins.io/browse/JENKINS-20027) m2release-plugin - [Fix](https://github.com/jenkinsci/m2release-plugin/commit/7ee2284e0515ae0aeb784188c670de34c3b1f0c6)
- [JENKINS-11398](https://issues.jenkins.io/browse/JENKINS-11398) cobertura-plugin - [Fix](https://github.com/jenkinsci/cobertura-plugin/commit/05dd95998ac64bcf37d959b40a365bf6f4ad83b1)


<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
    - Not sure how to test this, I'm hoping that by opening a PR some CI builds will run

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->

Fixes: [JENKINS-61336](https://issues.jenkins.io/browse/JENKINS-61336)